### PR TITLE
File Storage bindings (needed for Stream)

### DIFF
--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -1,0 +1,117 @@
+#include "file_storage.hpp"
+#include "utils.hpp"
+
+using namespace v8;
+
+Nan::Persistent<Function> FileStorage::constructor;
+
+NAN_MODULE_INIT(FileStorage::Init) {
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(NewInstance);
+  tpl->SetClassName(Nan::New("FileStorage").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  Nan::SetPrototypeMethod(tpl, "fileName", file_name);
+  Nan::SetPrototypeMethod(tpl, "filePath", file_path);
+  Nan::SetPrototypeMethod(tpl, "fileSize", file_size);
+  Nan::SetPrototypeMethod(tpl, "fileOffset", file_offset);
+  Nan::SetPrototypeMethod(tpl, "pieceLength", piece_length);
+
+  constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
+  Nan::Set(target, Nan::New("FileStorage").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
+}
+
+Local<Object> FileStorage::New(libtorrent::file_storage fs) {
+    Nan::EscapableHandleScope scope;
+
+    Local<Function> cons = Nan::New(constructor);
+
+    Nan::MaybeLocal<Object> obj = cons->NewInstance(Nan::GetCurrentContext());
+
+    Nan::ObjectWrap::Unwrap<FileStorage>(obj.ToLocalChecked())->file_storage_ = fs;
+
+    return scope.Escape(obj.ToLocalChecked());
+}
+
+NAN_METHOD(FileStorage::NewInstance) {
+  if (!info.IsConstructCall()) {
+    Nan::ThrowTypeError("Use the new operator to create instances of this object.");
+    return;
+  }
+
+  FileStorage* obj = new FileStorage();
+
+  obj->Wrap(info.This());
+
+  RETURN(info.This());
+};
+
+NAN_METHOD(FileStorage::file_name) {
+  REQUIRE_ARGUMENTS(1);
+
+  uint32_t index;
+  if (ARGUMENTS_IS_NUMBER(0)) {
+    index = info[0]->IntegerValue();
+  } else {
+    Nan::ThrowTypeError("Index is expected to be a number.");
+    return;
+  }
+
+  std::string name = FileStorage::Unwrap(info.This())->file_name(index);
+
+  RETURN(Nan::New<String>(name).ToLocalChecked());
+};
+
+NAN_METHOD(FileStorage::file_path) {
+  REQUIRE_ARGUMENTS(1);
+
+  uint32_t index;
+  if (ARGUMENTS_IS_NUMBER(0)) {
+    index = info[0]->IntegerValue();
+  } else {
+    Nan::ThrowTypeError("Index is expected to be a number.");
+    return;
+  }
+
+  std::string path = FileStorage::Unwrap(info.This())->file_path(index);
+
+  RETURN(Nan::New<String>(path).ToLocalChecked());
+};
+
+NAN_METHOD(FileStorage::file_size) {
+  REQUIRE_ARGUMENTS(1);
+
+  uint32_t index;
+  if (ARGUMENTS_IS_NUMBER(0)) {
+    index = info[0]->IntegerValue();
+  } else {
+    Nan::ThrowTypeError("Index is expected to be a number.");
+    return;
+  }
+
+  boost::int64_t size = FileStorage::Unwrap(info.This())->file_size(index);
+
+  RETURN(Nan::New<Number>(size));
+};
+
+NAN_METHOD(FileStorage::file_offset) {
+  REQUIRE_ARGUMENTS(1);
+
+  uint32_t index;
+  if (ARGUMENTS_IS_NUMBER(0)) {
+    index = info[0]->IntegerValue();
+  } else {
+    Nan::ThrowTypeError("Index is expected to be a number.");
+    return;
+  }
+
+  boost::int64_t offset = FileStorage::Unwrap(info.This())->file_offset(index);
+
+  RETURN(Nan::New<Number>(offset));
+};
+
+NAN_METHOD(FileStorage::piece_length) {
+
+  int piece_length = FileStorage::Unwrap(info.This())->piece_length();
+
+  RETURN(Nan::New<Number>(piece_length));
+};

--- a/src/file_storage.hpp
+++ b/src/file_storage.hpp
@@ -1,0 +1,31 @@
+#ifndef LIBTORRENT_NODE_FILE_STORAGE_HPP
+#define LIBTORRENT_NODE_FILE_STORAGE_HPP
+
+#include <nan.h>
+#include <libtorrent/file_storage.hpp>
+
+using namespace v8;
+
+class FileStorage: public Nan::ObjectWrap {
+    public:
+      static NAN_MODULE_INIT(Init);
+      static Local<Object> New(libtorrent::file_storage fs);
+      static libtorrent::file_storage*  Unwrap(const Local<Object>& obj) {
+        FileStorage* fs = Nan::ObjectWrap::Unwrap<FileStorage>(obj);
+        return &fs->file_storage_;
+      };
+
+    private:
+      libtorrent::file_storage file_storage_;
+
+      static Nan::Persistent<Function> constructor;
+
+      static NAN_METHOD(NewInstance);
+      static NAN_METHOD(file_name);
+      static NAN_METHOD(file_path);
+      static NAN_METHOD(file_size);
+      static NAN_METHOD(file_offset);
+      static NAN_METHOD(piece_length);
+
+};
+#endif // LIBTORRENT_NODE_ERROR_CODE_HPP

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -11,6 +11,7 @@
 #include "torrent_info.h"
 #include "alert.hpp"
 #include "state_t.hpp"
+#include "file_storage.hpp"
 
 namespace libtorrent {
 namespace node {
@@ -18,6 +19,7 @@ namespace node {
 NAN_MODULE_INIT(Init) {
   TorrentHandle::Init(target);
   TorrentInfo::Init(target);
+  FileStorage::Init(target);
   libtorrent::node::Session::Init(target);
   libtorrent::node::alert_types::InitAlertTypes(target);
   state_t::Init(target);

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -2,6 +2,7 @@
 #include "utils.hpp"
 #include "entry.hpp"
 #include "sha1_hash.hpp"
+#include "file_storage.hpp"
 
 #include <libtorrent/create_torrent.hpp>
 
@@ -19,6 +20,7 @@ NAN_MODULE_INIT(TorrentInfo::Init) {
   Nan::SetPrototypeMethod(tpl, "toBencodedEntry", to_bencoded_entry);
   Nan::SetPrototypeMethod(tpl, "isValid", is_valid);
   Nan::SetPrototypeMethod(tpl, "infoHash", info_hash);
+  Nan::SetPrototypeMethod(tpl, "files", files);
 
   constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
   Nan::Set(target, Nan::New("TorrentInfo").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
@@ -84,14 +86,14 @@ NAN_METHOD(TorrentInfo::total_size) {
 
 NAN_METHOD(TorrentInfo::piece_length) {
 
-    int piece_length = TorrentInfo::Unwrap(info.This())->total_size();
+    int piece_length = TorrentInfo::Unwrap(info.This())->piece_length();
 
     info.GetReturnValue().Set(Nan::New<v8::Number>(piece_length));
 }
 
 NAN_METHOD(TorrentInfo::num_pieces) {
 
-    int num_pieces = TorrentInfo::Unwrap(info.This())->total_size();
+    int num_pieces = TorrentInfo::Unwrap(info.This())->num_pieces();
 
     info.GetReturnValue().Set(Nan::New<v8::Number>(num_pieces));
 }
@@ -116,4 +118,13 @@ NAN_METHOD(TorrentInfo::info_hash) {
     libtorrent::sha1_hash h(TorrentInfo::Unwrap(info.This())->info_hash());
 
     RETURN(libtorrent::node::sha1_hash::encode(h));
+};
+
+NAN_METHOD(TorrentInfo::files) {
+    auto ti = TorrentInfo::Unwrap(info.This());
+    libtorrent::file_storage files = ti->files();
+
+    v8::Local<v8::Object> ret = FileStorage::New(files);
+
+    RETURN(ret);
 };

--- a/src/torrent_info.h
+++ b/src/torrent_info.h
@@ -31,6 +31,7 @@ class TorrentInfo: public Nan::ObjectWrap {
       static NAN_METHOD(to_bencoded_entry);
       static NAN_METHOD(is_valid);
       static NAN_METHOD(info_hash);
+      static NAN_METHOD(files);
 
 };
 


### PR DESCRIPTION
This PR had the FileStorage wrapper needed to have the streaming feature working.

- [x] file_name
- [x] file_path
- [x] file_size
- [x] file_offset

Also fix some implementation error in TorrenInfo (always called total_size instead of num_pieces and piece length).